### PR TITLE
Patch/race01

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl module HTTP::Cookies::Mozilla
 
-2.021 2016-01-27T19:44:59Z
+2.031 2016-01-27T19:44:59Z
 	* Freshen the distro, give Flavio credit, and update the expiry
 	on a cookie that would make a test fail. This module has been around
 	for a long time!

--- a/Changes
+++ b/Changes
@@ -1,13 +1,16 @@
 Revision history for Perl module HTTP::Cookies::Mozilla
 
 2.031 2016-01-27T19:44:59Z
-	* Freshen the distro, give Flavio credit, and update the expiry
-	on a cookie that would make a test fail. This module has been around
+	* Freshen the distro, give Flavio credit, and restored cookie
+	removed in 2.03 with updated expiry time. This module has been around
 	for a long time!
    * Added workaround to tests for saving cookies for addressing a
    rare race condition in the interaction with HTTP::Cookies.
    * No need to upgrade from 2.01 on. No need to upgrade from a previous
    version unless you need FireFox 3 support.
+
+2.03 - 2011-03-14T22:49:00Z
+   * (polettix) Removed one cookie from usatoday in test suite.
 
 2.02 - 2008-09-02T01:59:00Z
    * (polettix) Hopefully fixed annoyances that make the test

--- a/Changes
+++ b/Changes
@@ -1,9 +1,20 @@
 Revision history for Perl module HTTP::Cookies::Mozilla
 
-2.011 2016-01-27T19:44:59Z
+2.021 2016-01-27T19:44:59Z
 	* Freshen the distro, give Flavio credit, and update the expiry
 	on a cookie that would make a test fail. This module has been around
 	for a long time!
+   * Added workaround to tests for saving cookies for addressing a
+   rare race condition in the interaction with HTTP::Cookies.
+   * No need to upgrade from 2.01 on. No need to upgrade from a previous
+   version unless you need FireFox 3 support.
+
+2.02 - 2008-09-02T01:59:00Z
+   * (polettix) Hopefully fixed annoyances that make the test
+   suite fail in Win32 platforms. Changed name to test file
+   to make Windows see it properly. There's no need to upgrade
+   if you already have 2.01 installed or you don't need
+   FireFox 3 support.
 
 2.01 - 2008-07-29
 	* (polettix) Added support for FireFox 3 SQLite cookies file.

--- a/t/TestRelaxDiff.pm
+++ b/t/TestRelaxDiff.pm
@@ -1,0 +1,69 @@
+package TestRelaxDiff;
+use strict;
+use warnings;
+use Text::Diff ();
+
+# there is a race condition between H::C::M calculating the parameter
+# max_age for H::C::set_cookie, and H::C::set_cookie calculating the
+# expiration time back. We might have hit that race condition, so we
+# might relax the diff if the difference is within certain bounds.
+sub diff {
+   my ($file1, $file2, $time_delta) = @_;
+   my $diff = Text::Diff::diff($file1, $file2);
+
+   # return immediately if the files are equal or there is no 
+   # way to relax the comparison
+   return $diff unless $diff || $time_delta;
+
+   # isolate differences
+   my (@minus, @plus);
+   for my $line (split /\n/, $diff) {
+      my $first_char = substr $line, 0, 1, '';
+
+      # we keep separators in the split, so that the comparison will
+      # take them into account later
+      my @fields = split /(\s+)/, $line;
+
+      # dispatch
+      push @minus, \@fields if $first_char eq '-';
+      push @plus,  \@fields if $first_char eq '+';
+   }
+
+   # first two items are diff's headers... they always differ
+   shift @minus;
+   shift @plus;
+
+   # we will compare @minus and @plus element by element
+   while (@minus) {
+      return $diff unless @plus; # no @plus? files differ heavily!
+
+      my $minus_line = shift @minus;
+      my $plus_line  = shift @plus;
+      return $diff if scalar(@$minus_line) != scalar(@$plus_line);
+
+      # we kept separators, so the expiration time is the ninth element.
+      # If they differ more than our relax boundary $time_delta, an
+      # error occurred and we have to fail
+      my $minus_expiration = $minus_line->[8];
+      my $plus_expiration  = $plus_line->[8];
+      return $diff
+         if abs($plus_expiration - $minus_expiration) > $time_delta;
+
+      # we will force the expiration time of plus to be the same as the
+      # expiration time for minus and rebuild the two strings, to see if
+      # they are the same now.
+      $plus_line->[8] = $minus_line->[8];
+      my $minus_string = join '', @$minus_line;
+      my $plus_string  = join '', @$plus_line;
+      return $diff if $minus_string ne $plus_string;
+   }
+
+   # if we arrive here, all comparisons were fine so far. If there are
+   # residual elements in @plus it's an error, otherwise the test was
+   # fine
+   return $diff if @plus;
+   return '';
+}
+
+1;
+

--- a/t/save.ff3.t
+++ b/t/save.ff3.t
@@ -1,10 +1,10 @@
 use Test::More tests => 8;
-use Text::Diff;
 
 use HTTP::Cookies::Mozilla;
 
 use lib 't';
 use TestSqliteCmd;
+use TestRelaxDiff ();
 
 my $dist_file = 't/cookies.sqlite';
 my $save_file = 't/cookies2.sqlite';
@@ -38,6 +38,8 @@ sub check {
 
    my %Domains = qw( .ebay.com 2 .usatoday.com 3 );
 
+   my $start = time();
+
    my $jar = HTTP::Cookies::Mozilla->new(File => $dist_file);
    isa_ok($jar, 'HTTP::Cookies::Mozilla');
 
@@ -49,9 +51,11 @@ sub check {
    my $jar2 = HTTP::Cookies::Mozilla->new(File => $save_file);
    isa_ok($jar2, 'HTTP::Cookies::Mozilla');
 
+   my $time_delta = time() - $start;
+
    $jar2->save($txt_file2);
 
-   my $diff = Text::Diff::diff($txt_file1, $txt_file2);
+   my $diff = TestRelaxDiff::diff($txt_file1, $txt_file2, $time_delta);
    my $same = not $diff;
    ok($same, "Saved file is same as original ($condition)");
    print STDERR $diff;

--- a/t/save.t
+++ b/t/save.t
@@ -12,13 +12,83 @@ my $save_file = 't/cookies2.txt';
 my %Domains = qw( .ebay.com 2 .usatoday.com 3 );
 
 
+my $start = time();
 my $jar = HTTP::Cookies::Mozilla->new( File => $dist_file );
-isa_ok( $jar, 'HTTP::Cookies::Mozilla' );
+my $time_delta = time() - $start;
 
+isa_ok( $jar, 'HTTP::Cookies::Mozilla' );
 my $result = $jar->save( $save_file );
 
 my $diff = Text::Diff::diff( $dist_file, $save_file );
 my $same = not $diff;
+
+if ((! $same) && $time_delta) { # adjust $diff based on pre-analysis
+
+   # there is a race condition between H::C::M calculating the parameter
+   # max_age for H::C::set_cookie, and H::C::set_cookie calculating the
+   # expiration time back. We might have hit that race condition, so we
+   # will clear $diff if this is actually the case.
+
+   # isolate differences
+   my (@minus, @plus);
+   for my $line (split /\n/, $diff) {
+      my $first_char = substr $line, 0, 1;
+      my @fields = split /(\s+)/, $line;
+      push @minus, \@fields if $first_char eq '-';
+      push @plus, \@fields if $first_char eq '+';
+   }
+
+   # first two items are diff's headers... they always differ
+   shift @minus;
+   shift @plus;
+
+   # we will compare @minus and @plus element by element. If pairs are
+   # compatible, we will eventually clear $diff and $same, otherwise they
+   # will remain untouched
+   COMPARISON:
+   while (@minus) {
+
+      # if @plus is already empty, differences are not compatible and
+      # we can just leave this extended comparison. Remaining element(s)
+      # in @minus will flag the error condition.
+      last COMPARISON unless @plus;
+
+      # we want the line to remain in @minus and @plus until it's
+      # clear that they are compatible, so we don't do shift-ing
+      # here but only at the end of the loop
+      my $minus_line = $minus[0];
+      my $plus_line  = $plus[0];
+      last COMPARISON if scalar(@$minus_line) != scalar(@$plus_line);
+
+      # we kept separators, so the expiration time is the ninth element.
+      # If they differ more than our estimated $time_delta, an
+      # error occurred and we have to fail
+      my $minus_expiration = $minus_line->[8];
+      my $plus_expiration  = $plus_line->[8];
+      last COMPARISON
+         if ($plus_expiration - $minus_expiration) > $time_delta;
+
+      # we will force the expiration time of plus to be the same as the
+      # expiration time for minus and rebuild the two strings, to see if
+      # they are the same now. We have to get rid of the initial character
+      # because it's the '-' or '+'
+      $plus_line->[8] = $minus_line->[8];
+      my $minus_string = substr join('', @$minus_line), 1;
+      my $plus_string  = substr join('', @$plus_line), 1;
+      last COMPARISON if $minus_string ne $plus_string;
+
+      # differing lines are compatible, we can clear them out
+      shift @minus;
+      shift @plus;
+   }
+
+   # If all comparisons of @minus vs @plus were fine, and they had the
+   # same number of elements, both arrays are now empty. Any error
+   # condition left at least one element inside either one.
+   $diff = '' if (scalar(@minus) + scalar(@plus)) == 0;
+   $same = not $diff;
+}
+
 ok( $same, 'Saved file is same as original' );
 print STDERR $diff;
 

--- a/t/save.t
+++ b/t/save.t
@@ -1,7 +1,9 @@
 use Test::More 0.98;
-use Text::Diff;
 
 use HTTP::Cookies::Mozilla;
+
+use lib 't';
+use TestRelaxDiff ();
 
 my $class = 'HTTP::Cookies::Mozilla';
 use_ok( $class );
@@ -19,76 +21,8 @@ my $time_delta = time() - $start;
 isa_ok( $jar, 'HTTP::Cookies::Mozilla' );
 my $result = $jar->save( $save_file );
 
-my $diff = Text::Diff::diff( $dist_file, $save_file );
+my $diff = TestRelaxDiff::diff( $dist_file, $save_file, $time_delta );
 my $same = not $diff;
-
-if ((! $same) && $time_delta) { # adjust $diff based on pre-analysis
-
-   # there is a race condition between H::C::M calculating the parameter
-   # max_age for H::C::set_cookie, and H::C::set_cookie calculating the
-   # expiration time back. We might have hit that race condition, so we
-   # will clear $diff if this is actually the case.
-
-   # isolate differences
-   my (@minus, @plus);
-   for my $line (split /\n/, $diff) {
-      my $first_char = substr $line, 0, 1;
-      my @fields = split /(\s+)/, $line;
-      push @minus, \@fields if $first_char eq '-';
-      push @plus, \@fields if $first_char eq '+';
-   }
-
-   # first two items are diff's headers... they always differ
-   shift @minus;
-   shift @plus;
-
-   # we will compare @minus and @plus element by element. If pairs are
-   # compatible, we will eventually clear $diff and $same, otherwise they
-   # will remain untouched
-   COMPARISON:
-   while (@minus) {
-
-      # if @plus is already empty, differences are not compatible and
-      # we can just leave this extended comparison. Remaining element(s)
-      # in @minus will flag the error condition.
-      last COMPARISON unless @plus;
-
-      # we want the line to remain in @minus and @plus until it's
-      # clear that they are compatible, so we don't do shift-ing
-      # here but only at the end of the loop
-      my $minus_line = $minus[0];
-      my $plus_line  = $plus[0];
-      last COMPARISON if scalar(@$minus_line) != scalar(@$plus_line);
-
-      # we kept separators, so the expiration time is the ninth element.
-      # If they differ more than our estimated $time_delta, an
-      # error occurred and we have to fail
-      my $minus_expiration = $minus_line->[8];
-      my $plus_expiration  = $plus_line->[8];
-      last COMPARISON
-         if ($plus_expiration - $minus_expiration) > $time_delta;
-
-      # we will force the expiration time of plus to be the same as the
-      # expiration time for minus and rebuild the two strings, to see if
-      # they are the same now. We have to get rid of the initial character
-      # because it's the '-' or '+'
-      $plus_line->[8] = $minus_line->[8];
-      my $minus_string = substr join('', @$minus_line), 1;
-      my $plus_string  = substr join('', @$plus_line), 1;
-      last COMPARISON if $minus_string ne $plus_string;
-
-      # differing lines are compatible, we can clear them out
-      shift @minus;
-      shift @plus;
-   }
-
-   # If all comparisons of @minus vs @plus were fine, and they had the
-   # same number of elements, both arrays are now empty. Any error
-   # condition left at least one element inside either one.
-   $diff = '' if (scalar(@minus) + scalar(@plus)) == 0;
-   $same = not $diff;
-}
-
 ok( $same, 'Saved file is same as original' );
 print STDERR $diff;
 

--- a/t/test_manifest
+++ b/t/test_manifest
@@ -3,3 +3,4 @@ pod.t
 pod_coverage.t
 load.t
 save.t
+save.ff3.t


### PR DESCRIPTION
The diff function is now factored into its own TestRelaxDiff.pm test module and performs a relaxed comparison when there is the chance of a race condition. The new diff function is used both in save.t and save.ff3.t.

Test save.ff3.t has been activated in the test_manifest.

Changes now contains the text for the latest change of [release 2.03 on CPAN](https://metacpan.org/release/POLETTIX/HTTP-Cookies-Mozilla-2.03). Next release should probably be 2.031 or higher because of this, we might plan for a developer release though.

I don't know why the distro 2.03 does not contain the change notice for 2.03... I restored it as well anyway.
