### PR TITLE
Patch/race02

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl module HTTP::Cookies::Mozilla
 
-2.021 2016-01-27T19:44:59Z
+2.031 2016-01-27T19:44:59Z
 	* Freshen the distro, give Flavio credit, and update the expiry
 	on a cookie that would make a test fail. This module has been around
 	for a long time!

--- a/Changes
+++ b/Changes
@@ -1,13 +1,16 @@
 Revision history for Perl module HTTP::Cookies::Mozilla
 
 2.031 2016-01-27T19:44:59Z
-	* Freshen the distro, give Flavio credit, and update the expiry
-	on a cookie that would make a test fail. This module has been around
+	* Freshen the distro, give Flavio credit, and restored cookie
+	removed in 2.03 with updated expiry time. This module has been around
 	for a long time!
    * Added workaround to tests for saving cookies for addressing a
    rare race condition in the interaction with HTTP::Cookies.
    * No need to upgrade from 2.01 on. No need to upgrade from a previous
    version unless you need FireFox 3 support.
+
+2.03 - 2011-03-14T22:49:00Z
+   * (polettix) Removed one cookie from usatoday in test suite.
 
 2.02 - 2008-09-02T01:59:00Z
    * (polettix) Hopefully fixed annoyances that make the test

--- a/Changes
+++ b/Changes
@@ -1,9 +1,20 @@
 Revision history for Perl module HTTP::Cookies::Mozilla
 
-2.011 2016-01-27T19:44:59Z
+2.021 2016-01-27T19:44:59Z
 	* Freshen the distro, give Flavio credit, and update the expiry
 	on a cookie that would make a test fail. This module has been around
 	for a long time!
+   * Added workaround to tests for saving cookies for addressing a
+   rare race condition in the interaction with HTTP::Cookies.
+   * No need to upgrade from 2.01 on. No need to upgrade from a previous
+   version unless you need FireFox 3 support.
+
+2.02 - 2008-09-02T01:59:00Z
+   * (polettix) Hopefully fixed annoyances that make the test
+   suite fail in Win32 platforms. Changed name to test file
+   to make Windows see it properly. There's no need to upgrade
+   if you already have 2.01 installed or you don't need
+   FireFox 3 support.
 
 2.01 - 2008-07-29
 	* (polettix) Added support for FireFox 3 SQLite cookies file.

--- a/t/save.t
+++ b/t/save.t
@@ -12,16 +12,32 @@ my $save_file = 't/cookies2.txt';
 my %Domains = qw( .ebay.com 2 .usatoday.com 3 );
 
 
-my $jar = HTTP::Cookies::Mozilla->new( File => $dist_file );
+# get cookie jar, attempt multiple times to be sure to operate in the
+# same second (time-wise) so we can avoid race condition with
+# HTTP::Cookies
+my ($jar, $time_delta);
+for my $attempt (1 .. 5) {
+   my $start = time();
+   $jar = HTTP::Cookies::Mozilla->new( File => $dist_file );
+   $time_delta = time() - $start;
+   last unless $time_delta > 0;
+}
+
 isa_ok( $jar, 'HTTP::Cookies::Mozilla' );
 
-my $result = $jar->save( $save_file );
+SKIP: {
+   skip 'could not avoid race condition', 1
+      if $time_delta > 0;
 
-my $diff = Text::Diff::diff( $dist_file, $save_file );
-my $same = not $diff;
-ok( $same, 'Saved file is same as original' );
-print STDERR $diff;
+   my $result = $jar->save( $save_file );
 
-END { unlink $save_file }
+   my $diff = Text::Diff::diff( $dist_file, $save_file );
+   my $same = not $diff;
+   ok( $same, 'Saved file is same as original' );
+   print STDERR $diff;
+
+};
+
+END { unlink $save_file if $jar }
 
 done_testing();

--- a/t/test_manifest
+++ b/t/test_manifest
@@ -3,3 +3,4 @@ pod.t
 pod_coverage.t
 load.t
 save.t
+save.ff3.t


### PR DESCRIPTION
Alternative set of tests for working around race condition, skipping final diff in case it's not safe (which should be pretty rare with 5 attempts in a row). Tests should be quite simpler now. Retrieval of a cookie jar and associated time for constructor might be factored into a function to make test clearer, this code is just a proof of concept.
